### PR TITLE
remove socialize:user-presence dependancy

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     name: "socialize:messaging",
     summary: "A social messaging package",
-    version: "0.5.1",
+    version: "0.5.2",
     git:"https://github.com/copleykj/socialize-messaging.git"
 });
 
@@ -9,7 +9,7 @@ Package.onUse(function(api) {
     api.versionsFrom("1.0.2.1");
 
     api.use([
-        "check", "socialize:user-model@0.1.7", "socialize:user-presence@0.3.4", "socialize:server-time@0.1.2"
+        "check", "socialize:user-model@0.1.7", "socialize:server-time@0.1.2"
     ]);
 
     //Add the conversation-model files
@@ -28,4 +28,3 @@ Package.onUse(function(api) {
 
     api.export(["Conversation", "Message", "Participant"]);
 });
-

--- a/participant-model/server/server.js
+++ b/participant-model/server/server.js
@@ -43,13 +43,15 @@ ParticipantsCollection.after.update(function(userId, document){
     }
 });
 
+if (Package['socialize:user-presence']) {
 
+  UserPresence.onCleanup(function(sessionIds){
+      if(sessionIds){
+          ParticipantsCollection.update({observing:{$in:sessionIds}}, {$pullAll:{observing:sessionIds}}, {multi:true});
+      }else{
+          ParticipantsCollection.update({}, {$set:{observing:[]}}, {multi:true});
 
-UserPresence.onCleanup(function(sessionIds){
-    if(sessionIds){
-        ParticipantsCollection.update({observing:{$in:sessionIds}}, {$pullAll:{observing:sessionIds}}, {multi:true});
-    }else{
-        ParticipantsCollection.update({}, {$set:{observing:[]}}, {multi:true});
+      }
+  });
 
-    }
-});
+}


### PR DESCRIPTION
im using another package for user presence status and dont want to have extra 2 collections presense:servers & presence:user-sessions . One can add sociallize:user-presence separately their shouldn't be any dependency for adding that package and 2 extra collections.