### PR TITLE
Fix deploy issue with uglify

### DIFF
--- a/.versions
+++ b/.versions
@@ -32,7 +32,7 @@ localstorage@1.0.5
 logging@1.0.8
 matb33:collection-hooks@0.8.1
 mdg:validation-error@0.2.0
-meteor@1.1.10
+meteor@1.3
 minimongo@1.0.10
 mongo@1.1.3
 mongo-id@1.0.1
@@ -52,7 +52,7 @@ socialize:messaging@0.5.3
 socialize:server-presence@0.1.3
 socialize:server-time@0.1.2
 socialize:user-model@0.1.7
-socialize:user-presence@0.3.4
+socialize:user-presence@0.4.0
 spacebars@1.0.7
 spacebars-compiler@1.0.7
 tracker@1.0.9

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     name: "socialize:messaging",
     summary: "A social messaging package",
-    version: "0.5.0",
+    version: "0.5.1",
     git:"https://github.com/copleykj/socialize-messaging.git"
 });
 
@@ -9,7 +9,7 @@ Package.onUse(function(api) {
     api.versionsFrom("1.0.2.1");
 
     api.use([
-        "socialize:user-model@0.1.7", "socialize:user-presence@0.3.4", "socialize:server-time@0.1.2"
+        "check", "socialize:user-model@0.1.7", "socialize:user-presence@0.3.4", "socialize:server-time@0.1.2"
     ]);
 
     //Add the conversation-model files

--- a/package.js
+++ b/package.js
@@ -1,15 +1,15 @@
 Package.describe({
     name: 'socialize:messaging',
     summary: 'A social messaging package',
-    version: '0.5.3',
+    version: '0.5.4',
     git: 'https://github.com/copleykj/socialize-messaging.git',
 });
 
 Package.onUse((api) => {
-    api.versionsFrom('1.0.2.1');
+    api.versionsFrom('1.3');
 
     api.use([
-        'check', 'socialize:user-model@0.1.7', 'socialize:user-presence@0.3.4', 'socialize:server-time@0.1.2',
+        'ecmascript', 'check', 'socialize:user-model@0.1.7', 'socialize:user-presence@0.4.0', 'socialize:server-time@0.1.2',
     ]);
 
     // Add the conversation-model files


### PR DESCRIPTION
When trying to deploy to production with the newest version of messaging I got a crazy error from uglify, that would not shown unless using `meteor --production`. More on this issue here: https://github.com/meteor/meteor/issues/5387

Fix is simple, the package needs to use the ecmascript package. This also means to bump the minimal Meteor version to 1.3.

Cheers!